### PR TITLE
support b:clurin

### DIFF
--- a/autoload/clurin.vim
+++ b/autoload/clurin.vim
@@ -76,6 +76,9 @@ function! s:getdefs() abort " {{{
   endif
   let q = []
   let p = []
+  if has_key(b:, 'clurin')
+    call add(p, b:clurin)
+  endif
   for ft in [&filetype, '-']
     if has_key(conf, ft)
       call add(p, conf[ft])


### PR DESCRIPTION
`g:clurin[&filetype]`より`b:clurin`の方が好みなので
(ftpluginやlocalrc等で設定が出来る為)

個人的な好みのLvなのでRejectするかどうかはお任せします
