### PR TITLE
'replace'で呼び出す関数で置換処理を終えたい。

### DIFF
--- a/autoload/clurin.vim
+++ b/autoload/clurin.vim
@@ -200,6 +200,9 @@ function! s:replace(m, cnt) abort " {{{
   let d = a:m.conf.group[idx]
   if type(d.replace) == type(function('tr'))
     let str = d.replace(a:m.text, c, d)
+    if get(a:m.conf, 'quit', 0)
+      return
+    endif
   else
     let str = substitute(d.replace, '\\1', a:m.text, 'g')
   endif


### PR DESCRIPTION
'replace'の関数が返した文字列で置換するのではなく、関数内で置換処理を終了させてしまいたいです。
'quit'オプションを1にすることで関数を呼び出した後に処理を終了します。

下記の設定はRubyの`do ~ end`と`{ ~ }`を切り替えます。
複数行の置換をするために関数内で置換を終わらせる必要がありました。

```vim
function g:RubyBlockOneline(str, cnt, def) abort
  s/\v\s*do\s*(\|.*\|)?\_s*(.*)\_s*end/{\1 \2}
endfunction

function g:RubyBlockMultiline(str, cnt, def) abort
  let save_pos = getpos('.')
  s/\v\s*\{(\|.*\|)?\_s*(.*)\_s*\}$/ do \1\r\2\rend
  call setpos('.', save_pos)
endfunction

let g:clurin = {
      \ 'ruby': {'def': [
      \   {'quit': 1, 'group': [
      \     {'pattern': '\v\s*do\s*(\|.*\|)?', 'replace': function('g:RubyBlockMultiline')},
      \     {'pattern': '\v\s*\{(\|.*\|)?\_s*.*\_s*\}$', 'replace': function('g:RubyBlockOneline')},
      \   ]}
      \ ]}
      \ }
```

オプション名は適当に変更してください。
テストはどこに書けばいいのか迷ったので保留してます。(receipt.vim?)


### TODO
- [ ] ドキュメントに追記
- [ ] テスト